### PR TITLE
Ability to append invoice note along with price text

### DIFF
--- a/index.js
+++ b/index.js
@@ -235,9 +235,8 @@ async function createDraftInvoice(token, invoiceDetails = {}) {
     vergilerDahilToplamTutar: invoiceDetails.grandTotalInclVAT.toFixed(2).toString(),
     toplamMasraflar: invoiceDetails.toplamMasraflar || "0",
     odenecekTutar: invoiceDetails.paymentTotal.toFixed(2).toString(),
-    not: convertPriceToText(invoiceDetails.paymentTotal)
- 
-  };
+    not: `${convertPriceToText(invoiceDetails.paymentTotal)}${invoiceDetails.note ? `\n\n${invoiceDetails.note}` : ''}`
+    };
   const invoice = await runCommand(
     token,
     ...COMMANDS.createDraftInvoice,
@@ -456,5 +455,6 @@ module.exports = {
   sendSignSMSCode,
   verifySignSMSCode,
   getUserData,
-  updateUserData
+  updateUserData,
+  convertPriceToText
 };

--- a/index.js
+++ b/index.js
@@ -455,6 +455,5 @@ module.exports = {
   sendSignSMSCode,
   verifySignSMSCode,
   getUserData,
-  updateUserData,
-  convertPriceToText
+  updateUserData
 };


### PR DESCRIPTION
Currently, the payload forces `note`  to `convertPriceToText` result with this update if the user has a special note for the invoice, the note can be appended after the price text.